### PR TITLE
[feature/0056] 총 구독 금액 계산 API 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { ConfigModuleValidationSchema } from './configs/env-validation.config';
 import { FakerModule } from './faker/faker.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { RedisModule } from '@nestjs-modules/ioredis';
+import { TotalPriceModule } from './user/total-price.module';
 
 const typeOrmModuleOptions = {
   useFactory: async (
@@ -51,6 +52,7 @@ const typeOrmModuleOptions = {
     PlatformsModule,
     CategoryModule,
     FakerModule,
+    TotalPriceModule,
     ScheduleModule.forRoot(),
     RedisModule.forRootAsync({
       imports: [ConfigModule],

--- a/src/user/total-price.controller.ts
+++ b/src/user/total-price.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Param, ParseIntPipe, NotFoundException } from '@nestjs/common';
+import { TotalPriceService } from './total-price.service';
+
+@Controller('total')
+export class TotalPriceController {
+  constructor(private readonly totalPriceService: TotalPriceService) {}
+
+  @Get(':userId/price')
+  async getUserMonthlySubscription(
+    @Param('userId', ParseIntPipe) userId: number,
+  ): Promise<number> {
+    return this.totalPriceService.getUserMonthlySubscription(userId);
+
+}
+}

--- a/src/user/total-price.module.ts
+++ b/src/user/total-price.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TotalPriceService } from './total-price.service';
+import { TotalPriceController } from './total-price.controller';
+import { SubscriptionHistory } from './entities/subscription-histories.entity';
+import { TotalPriceRepository } from './total-price.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SubscriptionHistory])],
+  providers: [ TotalPriceService,TotalPriceRepository],
+  controllers: [TotalPriceController],
+})
+export class TotalPriceModule {}

--- a/src/user/total-price.repository.ts
+++ b/src/user/total-price.repository.ts
@@ -9,6 +9,7 @@ export class TotalPriceRepository {
     @InjectRepository(SubscriptionHistory)
     private readonly repository: Repository<SubscriptionHistory>,
   ) {}
+  
   async getMonthlySubscriptionUser(userId: number): Promise<number> {
    try{ const result = await this.repository.query(`
       SELECT COALESCE(SUM(sh.price), 0) AS total_price

--- a/src/user/total-price.repository.ts
+++ b/src/user/total-price.repository.ts
@@ -1,0 +1,30 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Injectable} from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { SubscriptionHistory } from './entities/subscription-histories.entity';
+
+@Injectable()
+export class TotalPriceRepository {
+  constructor(
+    @InjectRepository(SubscriptionHistory)
+    private readonly repository: Repository<SubscriptionHistory>,
+  ) {}
+  async getMonthlySubscriptionUser(userId: number): Promise<number> {
+   try{ const result = await this.repository.query(`
+      SELECT COALESCE(SUM(sh.price), 0) AS total_price
+      FROM user_subscription us
+      INNER JOIN subscription_history sh
+        ON us.id = sh.user_subscription_id
+      WHERE us.user_id = ?
+        AND LEFT(sh.start_at, 7) = LEFT(CURRENT_DATE, 7)
+        AND us.deleted_at IS NULL
+        AND (sh.stop_request_at IS NULL OR sh.start_at < sh.stop_request_at);
+`, [userId]);
+
+    return result[0]?.total_price || 0;
+  }catch(err){
+    console.error('총 구독 금액을 계산하는데 문제가 생겼습니다.', err)
+    throw new Error('총 구독 금액을 계산하는데 문제가 생겼습니다')
+  }
+}
+}

--- a/src/user/total-price.service.ts
+++ b/src/user/total-price.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, Logger } from '@nestjs/common';;
+import { TotalPriceRepository } from './total-price.repository';
+
+
+@Injectable()
+export class TotalPriceService {
+  private readonly logger = new Logger(TotalPriceService.name);
+
+  constructor(
+    private readonly totalPriceRepository: TotalPriceRepository,
+  ) {}
+
+  // 사용자별 월간 구독 금액 API
+  async getUserMonthlySubscription(userId: number): Promise<number> {
+    try {
+      return await this.totalPriceRepository.getMonthlySubscriptionUser(userId);
+    } catch (err) {
+      this.logger.error('사용자 구독 금액 계산 실패', err.stack);
+      throw new Error('사용자 구독 금액 계산 실패');
+    }
+  }
+}


### PR DESCRIPTION
총 구독 금액 계산 API 추가하여 푸쉬했습니다. 현재 사용자가 요청하면 계산 되는 로직으로 구현이 되어 있습니다. 프론트엔드에서는 새로고침 버튼을 추가하여 해당 주소를 가져다 붙여가지고 관리하도록 만들면 될 것 같습니다. 보시고 고쳐야 할 것 같은 점 말씀 주시면 고치겠습니다